### PR TITLE
Bugfix in dbdata.get_meal_date

### DIFF
--- a/src/dbdata.py
+++ b/src/dbdata.py
@@ -547,6 +547,7 @@ def get_meal_date():
     The function does not take any arguments and returns the date of the meal for today.
     """
 
-    sql_statement = f"SELECT EDAT FROM ESS WHERE isLatest = TRUE"
+    sql_statement = f"SELECT EDAT FROM ESS WHERE is_latest = TRUE"
     date = dbconnector.sql(sql_statement)
-    date = json.loads(json.dumps(date)[0][0])
+    date = json.loads(json.dumps(date))[0][0]
+    return date


### PR DESCRIPTION
## Summary
- fix malformed JSON handling in `get_meal_date`
- query `is_latest` column correctly and return the selected date

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_68527b4f5ed08333b49cc38aad6667a9