### PR TITLE
Add ASCII architecture diagram

### DIFF
--- a/Diagrams/architecture_diagram.txt
+++ b/Diagrams/architecture_diagram.txt
@@ -1,0 +1,7 @@
+main.py -> webwork.py -> dbdata.py -> dbconnector.py
+           |              |
+           |              -> vf_data.py
+           |              -> getConfig.py
+           |
+           -> tablegenerator.py
+           -> dbexport.py -> sendExport.py

--- a/Diagrams/classes_code_structure.dot
+++ b/Diagrams/classes_code_structure.dot
@@ -1,0 +1,4 @@
+digraph "classes_code_structure" {
+rankdir=BT
+charset="utf-8"
+}

--- a/Diagrams/packages_code_structure.dot
+++ b/Diagrams/packages_code_structure.dot
@@ -1,0 +1,37 @@
+digraph "packages_code_structure" {
+rankdir=BT
+charset="utf-8"
+"src" [color="black", label=<src>, shape="box", style="solid"];
+"src.dbconnector" [color="black", label=<src.dbconnector>, shape="box", style="solid"];
+"src.dbdata" [color="black", label=<src.dbdata>, shape="box", style="solid"];
+"src.dbexport" [color="black", label=<src.dbexport>, shape="box", style="solid"];
+"src.formatprices" [color="black", label=<src.formatprices>, shape="box", style="solid"];
+"src.getConfig" [color="black", label=<src.getConfig>, shape="box", style="solid"];
+"src.main" [color="black", label=<src.main>, shape="box", style="solid"];
+"src.sendExport" [color="black", label=<src.sendExport>, shape="box", style="solid"];
+"src.tablegenerator" [color="black", label=<src.tablegenerator>, shape="box", style="solid"];
+"src.vf_data" [color="black", label=<src.vf_data>, shape="box", style="solid"];
+"src.webwork" [color="black", label=<src.webwork>, shape="box", style="solid"];
+"src.dbconnector" -> "src.getConfig" [arrowhead="open", arrowtail="none"];
+"src.dbdata" -> "src.dbconnector" [arrowhead="open", arrowtail="none"];
+"src.dbdata" -> "src.formatprices" [arrowhead="open", arrowtail="none"];
+"src.dbdata" -> "src.getConfig" [arrowhead="open", arrowtail="none"];
+"src.dbdata" -> "src.vf_data" [arrowhead="open", arrowtail="none"];
+"src.dbexport" -> "src.dbdata" [arrowhead="open", arrowtail="none"];
+"src.dbexport" -> "src.getConfig" [arrowhead="open", arrowtail="none"];
+"src.dbexport" -> "src.sendExport" [arrowhead="open", arrowtail="none"];
+"src.main" -> "src.dbconnector" [arrowhead="open", arrowtail="none"];
+"src.main" -> "src.dbdata" [arrowhead="open", arrowtail="none"];
+"src.main" -> "src.dbexport" [arrowhead="open", arrowtail="none"];
+"src.main" -> "src.getConfig" [arrowhead="open", arrowtail="none"];
+"src.main" -> "src.vf_data" [arrowhead="open", arrowtail="none"];
+"src.main" -> "src.webwork" [arrowhead="open", arrowtail="none"];
+"src.sendExport" -> "src.getConfig" [arrowhead="open", arrowtail="none"];
+"src.vf_data" -> "src.dbdata" [arrowhead="open", arrowtail="none"];
+"src.vf_data" -> "src.getConfig" [arrowhead="open", arrowtail="none"];
+"src.webwork" -> "src.dbdata" [arrowhead="open", arrowtail="none"];
+"src.webwork" -> "src.formatprices" [arrowhead="open", arrowtail="none"];
+"src.webwork" -> "src.main" [arrowhead="open", arrowtail="none"];
+"src.webwork" -> "src.tablegenerator" [arrowhead="open", arrowtail="none"];
+"src.webwork" -> "src.vf_data" [arrowhead="open", arrowtail="none"];
+}

--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ Latest Main Branch running on: https://lsf-flilaapp.sellerbeckcloud.de/
 ## Database Design
 ![database_design.png](Screenshots%2Fdatabase_design.png)
 
+## Architecture Diagrams
+The `Diagrams/` folder now contains text diagrams describing the module
+relationships. You can render `packages_code_structure.dot` with Graphviz, or
+view the simplified ASCII overview below:
+
+```
+main.py -> webwork.py -> dbdata.py -> dbconnector.py
+           |              |
+           |              -> vf_data.py
+           |              -> getConfig.py
+           |
+           -> tablegenerator.py
+           -> dbexport.py -> sendExport.py
+```
+
 
 ## FAQ
 


### PR DESCRIPTION
## Summary
- replace binary module diagrams with ASCII version
- link text-based diagram in README

## Testing
- `PYTHONPATH=. pytest -q` *(fails: module 'getConfig' has no attribute 'get_config')*

------
https://chatgpt.com/codex/tasks/task_e_68527d369e5c833380ea1166b0486e6b